### PR TITLE
fix(cfn): fix Description encoding and resolve relative doc URL (#91)

### DIFF
--- a/deploy/cloudformation/admin-setup.yaml
+++ b/deploy/cloudformation/admin-setup.yaml
@@ -1,9 +1,10 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: >-
-  Mint admin one-time setup — creates shared infrastructure for all Mint users
+  Mint admin one-time setup - creates shared infrastructure for all Mint users
   in this account/region. Deploys IAM role and instance profile for Mint VMs,
   an encrypted EFS filesystem for persistent user storage, and a self-referencing
-  security group for NFS access. See docs/admin-setup.md for usage.
+  security group for NFS access.
+  See https://github.com/SpiceLabsHQ/Mint/blob/main/docs/admin-setup.md for usage.
 
 Parameters:
   VpcId:


### PR DESCRIPTION
Fixes two issues in the CloudFormation stack Description field:

- Replace em dash (—) with ASCII hyphen to prevent UTF-8 corruption in the AWS console
- Replace relative `docs/admin-setup.md` path with absolute GitHub URL so the link is meaningful in all CloudFormation rendering contexts

Closes #91