### PR TITLE
ci: delete pre-existing release before GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,11 @@ jobs:
       - name: Generate
         run: go generate ./...
 
+      - name: Delete existing release if present
+        run: gh release delete ${{ github.ref_name }} --yes 2>/dev/null || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
## Summary
- Adds a cleanup step before GoReleaser that deletes any pre-existing release for the tag
- Prevents the "Cannot upload assets to an immutable release" 422 error when a release is manually pre-created before GoReleaser runs
- No-op (`|| true`) when no release exists, so normal tag-push flows are unaffected

Ref: release pipeline fix