### PR TITLE
ci: convert pre-existing release to draft before GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Generate
         run: go generate ./...
 
-      - name: Delete existing release if present
-        run: gh release delete ${{ github.ref_name }} --yes 2>/dev/null || true
+      - name: Convert pre-existing release to draft if present
+        run: gh release edit ${{ github.ref_name }} --draft 2>/dev/null || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Replaces the previous `gh release delete` approach with `gh release edit --draft`
- When a release is pre-created (e.g. via `gh release create`), deleting it keeps the tag tainted — GitHub remembers "tag_name was used by an immutable release" even after deletion and rejects GoReleaser's PATCH
- Converting to draft instead makes the release mutable again; GoReleaser finds the existing draft (tag already set correctly), uploads assets, and publishes — without ever needing to change `tag_name`