### PR TITLE
Seed Renovate config for GitHub Actions updates [DEV-494]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["github-actions"],
+  "packageRules": [
+    {
+      "description": "SpiceLabsHQ reusable workflows: release-please monorepo tags like pepper-pr-review-v1.2.3",
+      "matchManagers": ["github-actions"],
+      "matchDatasources": ["github-tags"],
+      "matchPackageNames": ["SpiceLabsHQ/.github**"],
+      "versionCompatibility": "^(?<compatibility>.*)-v(?<version>.*)$",
+      "versioning": "semver"
+    }
+  ]
+}


### PR DESCRIPTION
Seeds `.github/renovate.json` (github-actions manager only) so GitHub Actions
refs — third-party actions and any
[SpiceLabsHQ/.github](https://github.com/SpiceLabsHQ/.github) reusable-workflow
pins — get update PRs instead of going stale silently. The config is inert until
the Mend Renovate GitHub App is installed on the org. Renovate was chosen over
Dependabot because Dependabot mis-handles the component-prefixed release tags
(`<workflow>-vX.Y.Z`) this org's reusable workflows use (details in DEV-494).
Version-update config cannot be inherited org-wide from the `.github` repo, so
it lives per-repo.

This repo has no legacy `@v1` reusable-workflow pins; this is the
config-seeding half of the DEV-494 sweep only.

Tracking: DEV-494