### PR TITLE
ci: SHA-pin third-party actions for actions-audit floor (DEV-511)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6
         with:
           version: latest
 
@@ -75,7 +75,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: go-semantic-release/action@v1
+      - uses: go-semantic-release/action@2e9dc4247a6004f8377781bef4cb9dad273a741f # v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           allow-initial-development-versions: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           cache: true
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: '~> v2'


### PR DESCRIPTION
## What

The actions-audit/zizmor floor requires third-party GitHub Actions to be pinned to a full 40-character commit SHA (`unpinned-uses`). This pins the three third-party actions flagged in the Mint repo, keeping the original tag as a trailing comment so Renovate and humans can still read the intended version.

## Actions pinned

- `.github/workflows/ci.yml`: `golangci/golangci-lint-action@v6` → `55c2c1448f86e01eaae002a5a3a9624417608d84 # v6`
- `.github/workflows/ci.yml`: `go-semantic-release/action@v1` → `2e9dc4247a6004f8377781bef4cb9dad273a741f # v1`
- `.github/workflows/release.yml`: `goreleaser/goreleaser-action@v6` → `e435ccd777264be153ace6237001ef4d979d3a7a # v6`

## Left on tags intentionally

First-party (`SpiceLabsHQ/*`) and `actions/*` / `github/*` uses are intentionally left on tags per the org `allow_tags_for` policy (`ref-pin`), so `actions/checkout`, `actions/setup-go`, and `actions/upload-artifact` are unchanged.

## Verification

Local zizmor run with the floor policy (`actions/*`, `github/*`, `SpiceLabsHQ/*` = ref-pin; `*` = hash-pin) at `--min-severity medium --min-confidence medium` reports **zero findings**.

https://claude.ai/code/session_01RuFxrsiBSjMCwkrn8JJAq9